### PR TITLE
fix error when a class key had multiple classes inside it

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,26 @@ function replaceSelectors(el, scoped, replaceClassName) {
 
   var newClasses = [];
   Object.keys(scoped.classes).forEach(function walkClass(scopeClass) {
+    var classes = scopeClass.split(' ');
+    // detect if a scopedClass is multiple classes and
+    // if so then add the collective class to the element
+    if (classes.length > 1) {
+      var classesNotFound = classes.filter((c) => !el.classList.contains(c));
+
+      if (classesNotFound.length > 0) {
+        return;
+      }
+
+      if (replaceClassName) {
+        newClasses.push(scoped.classes[scopeClass]);
+      } else {
+        classes.forEach(c => el.classList.remove(c));
+        el.classList.add(scoped.classes[scopeClass]);
+      }
+
+      return;
+    }
+
     if (el.classList.contains(scopeClass)) {
       if (replaceClassName) {
         newClasses.push(scoped.classes[scopeClass]);

--- a/test.js
+++ b/test.js
@@ -42,6 +42,30 @@ test('async removing unused classnames', t => {
   });
 });
 
+test('when replaceClassName is `true` should process a class key with multiple classes', t => {
+  t.plan(1);
+  const html = '<!DOCTYPE HTML><html><head><style>div[class="cell center"] { color: red; }'
+    + '</style></head><body><div class="cell center nice"></div></body></html>';
+  const expectedHtml = '<html><head></head><body><div class="cell_center_ycdMX div_el_ycdMX">'
+    + '</div></body></html>';
+  const actualDoc = jsdom(html);
+
+  scopeifyHtml({ replaceClassName: true }).sync(actualDoc);
+  t.equal(actualDoc.documentElement.outerHTML, expectedHtml);
+});
+
+test('when replaceClassName is `false` should process a class key with multiple classes', t => {
+  t.plan(1);
+  const html = '<!DOCTYPE HTML><html><head><style>div[class="cell center"] { color: red; }'
+    + '</style></head><body><div class="cell center nice"></div></body></html>';
+  const expectedHtml = '<html><head></head><body><div class="nice cell_center_ycdMX div_el_ycdMX">'
+    + '</div></body></html>';
+  const actualDoc = jsdom(html);
+
+  scopeifyHtml({ replaceClassName: false }).sync(actualDoc);
+  t.equal(actualDoc.documentElement.outerHTML, expectedHtml);
+});
+
 test('emails', t => {
   fixtures.forEach(fname => {
     const html = fs.readFileSync(`./fixtures/${fname}`);


### PR DESCRIPTION
```
DOMException: Failed to execute ‘contains’ on ‘DOMTokenList’: 
The token provided (‘cell center’) contains HTML space characters, which are not valid in tokens.
```